### PR TITLE
Use deep clones for data in Storage

### DIFF
--- a/lib/chrome/StorageArea.js
+++ b/lib/chrome/StorageArea.js
@@ -45,7 +45,7 @@ function StorageArea(chrome, storage, namespace) {
     var result = get(this._store, keys);
 
     defer(function () {
-      callback(result);
+      callback(_.cloneDeep(result));
     });
   });
 
@@ -77,10 +77,10 @@ function StorageArea(chrome, storage, namespace) {
         oldValue: this._store[key],
         newValue: items[key]
       };
-      this._store[key] = items[key];
+      this._store[key] = _.cloneDeep(items[key]);
     }
 
-    storage.onChanged.trigger(changes, namespace);
+    storage.onChanged.trigger(_.cloneDeep(changes), namespace);
 
     return (callback && defer(callback));
   });

--- a/test/unit/lib/chrome/Storage.spec.js
+++ b/test/unit/lib/chrome/Storage.spec.js
@@ -123,6 +123,36 @@ describe('chrome.storage', function () {
     });
   });
 
+  describe('storage data isolation', function () {
+    var mock;
+
+    before(function () {
+      api = new Storage();
+      mock = {
+        alpha: { user: { name: 'Hamburglar', pass: 'r0bbl3r0bble' } },
+        isNew: true
+      };
+    });
+
+    it('modifying original data after storing should not alter data in storage', function (done) {
+      api.sync.set(mock, function () {
+        mock.alpha.user.name = 'Grimmace';
+        hmt.assert.notEqual(mock.alpha.user.name, api.sync._store.alpha.user.name);
+        done();
+      });
+    });
+
+    it('modifying results should not alter the data in storage', function (done) {
+      api.sync.set(mock, function () {
+        api.sync.get(['alpha'], function (result) {
+          result.alpha.user.name = 'Ronald';
+          hmt.assert.notEqual(api.sync._store.alpha.user.name, 'Ronald');
+          done();
+        });
+      });
+    });
+  });
+
   describe('remove()', function () {
     beforeEach(function (done) {
       api = new Storage();


### PR DESCRIPTION
I spent half a day wondering why the data in storage was mysteriously changing during my unit tests.
